### PR TITLE
implement all listed enhancements (#6, #7, #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# hsyslog
+
+- Documentation can be found on [hackage][1].
+- Implementation is guided by the [GNU libc syslog documentation][2].
+
+  [1]: http://hackage.haskell.org/package/hsyslog-2.0
+  [2]: http://www.gnu.org/software/libc/manual/html_node/Submitting-Syslog-Messages.html

--- a/hsyslog.cabal
+++ b/hsyslog.cabal
@@ -12,15 +12,28 @@ Synopsis:               FFI interface to syslog(3) from POSIX.1-2001
 Description:            This library provides FFI bindings to syslog(3) from POSIX.1-2001.
                         See <http://www.opengroup.org/onlinepubs/009695399/basedefs/syslog.h.html> for
                         further details.
-Cabal-Version:          >= 1.6
+Cabal-Version:          >= 1.8
 Build-Type:             Simple
-Tested-With:            GHC >= 6.10.4 && <= 7.8.3
+Tested-With:            GHC >= 6.10.4 && <= 7.10.2
 
 Source-Repository head
   Type:                 git
   Location:             git://github.com/peti/hsyslog.git
 
 Library
+  Hs-Source-Dirs:       src
   Build-Depends:        base >= 3 && < 5
-  Extensions:           ForeignFunctionInterface
+                      , bytestring == 0.10.*
+  Extensions:           CApiFFI
+                      , ForeignFunctionInterface
+                      , OverloadedStrings
   Exposed-Modules:      System.Posix.Syslog
+
+Test-Suite tests
+  Hs-Source-Dirs:       test
+  Main-Is:              Main.hs
+  Type:                 exitcode-stdio-1.0
+  Build-Depends:        base
+                      , bytestring
+                      , hsyslog
+                      , QuickCheck

--- a/hsyslog.cabal
+++ b/hsyslog.cabal
@@ -1,5 +1,5 @@
 Name:                   hsyslog
-Version:                3
+Version:                4
 Copyright:              Copyright (c) 2004-2015 by Peter Simons
 License:                BSD3
 License-File:           LICENSE

--- a/src/System/Posix/Syslog.hsc
+++ b/src/System/Posix/Syslog.hsc
@@ -34,19 +34,21 @@ module System.Posix.Syslog
     -- * Configuring syslog
   , SyslogConfig (..)
   , defaultConfig
-    -- * The safe Haskell API to syslog
+    -- * The preferred Haskell API to syslog
+    -- | These are also the most performant calls to syslog, with the minimum
+    -- amount of 'CString' copying necessary.
   , withSyslog
   , SyslogFn
   , withSyslogTo
   , SyslogToFn
     -- * The unsafe Haskell API to syslog
-    -- | Using these functions provides no guarantee that the call to
-    -- 'openSyslog' has been made. For use only when an architecture cannot
-    -- support the 'withSyslog' bracketing.
-  , openSyslog
-  , closeSyslog
-  , syslog
-  , syslogTo
+    -- | Using these functions provides no guarantee that a call to '_openlog'
+    -- has been made. For use only when an architecture cannot support the
+    -- 'withSyslog' bracketing.
+  , openSyslogUnsafe
+  , closeSyslogUnsafe
+  , syslogUnsafe
+  , syslogToUnsafe
     -- * Low-level C functions
   , _openlog
   , _closelog
@@ -246,7 +248,7 @@ data SyslogConfig = SyslogConfig
 -- identifier.
 
 defaultConfig :: SyslogConfig
-defaultConfig = SyslogConfig "hsyslog" [NDELAY] [USER] NoMask
+defaultConfig = SyslogConfig "hsyslog" [ODELAY] [USER] NoMask
 
 -- |Bracket an 'IO' computation between calls to '_openlog', '_setlogmask', and
 -- '_closelog', and provide a logging function which can be used as follows:
@@ -260,8 +262,8 @@ defaultConfig = SyslogConfig "hsyslog" [NDELAY] [USER] NoMask
 
 withSyslog :: SyslogConfig -> (SyslogFn -> IO ()) -> IO ()
 withSyslog config f =
-    bracket_ (openSyslog config) closeSyslog $ do
-      useAsCString escape (\e -> f $ syslogSafe e [])
+    bracket_ (openSyslogUnsafe config) closeSyslogUnsafe $ do
+      useAsCString escape (\e -> f $ syslogEscaped e [])
       return ()
 
 -- |The type of logging function provided by 'withSyslog'.
@@ -277,8 +279,8 @@ type SyslogFn
 
 withSyslogTo :: SyslogConfig -> (SyslogToFn -> IO ()) -> IO ()
 withSyslogTo config f =
-    bracket_ (openSyslog config) closeSyslog $ do
-      useAsCString escape (f . syslogSafe)
+    bracket_ (openSyslogUnsafe config) closeSyslogUnsafe $ do
+      useAsCString escape (f . syslogEscaped)
       return ()
 
 -- |The type of function provided by 'withSyslogTo'.
@@ -289,8 +291,8 @@ type SyslogToFn
   -> ByteString -- ^ the message to log
   -> IO ()
 
-openSyslog :: SyslogConfig -> IO ()
-openSyslog (SyslogConfig ident opts facs mask) = do
+openSyslogUnsafe :: SyslogConfig -> IO ()
+openSyslogUnsafe (SyslogConfig ident opts facs mask) = do
     useAsCString ident (\i -> _openlog i cOpts cFacs)
     _setlogmask cMask
     return ()
@@ -299,14 +301,14 @@ openSyslog (SyslogConfig ident opts facs mask) = do
     cMask = fromPriorityMask mask
     cOpts = bitsOrWith fromOption opts
 
-closeSyslog :: IO ()
-closeSyslog = _closelog
+closeSyslogUnsafe :: IO ()
+closeSyslogUnsafe = _closelog
 
-syslog :: SyslogFn
-syslog = syslogTo []
+syslogUnsafe :: SyslogFn
+syslogUnsafe = syslogToUnsafe []
 
-syslogTo :: SyslogToFn
-syslogTo facs pris msg = useAsCString msg (_syslog (makePri facs pris))
+syslogToUnsafe :: SyslogToFn
+syslogToUnsafe facs pris msg = useAsCString msg (_syslog (makePri facs pris))
 
 -- |Open a connection to the system logger for a program. The string
 -- identifier passed as the first argument is prepended to every
@@ -337,7 +339,7 @@ foreign import ccall unsafe "setlogmask" _setlogmask :: CInt -> IO CInt
 -- string strerror(errno). A trailing newline may be added if needed.
 
 _syslog :: CInt -> CString -> IO ()
-_syslog int str = useAsCString escape $ \e -> _syslogSafe int e str
+_syslog int msg = useAsCString escape $ \e -> _syslogEscaped int e msg
 
 foreign import capi "syslog.h LOG_MASK" _LOG_MASK :: CInt -> CInt
 foreign import capi "syslog.h LOG_UPTO" _LOG_UPTO :: CInt -> CInt
@@ -352,12 +354,12 @@ makePri :: [Facility] -> [Priority] -> CInt
 makePri facs pris =
     _LOG_MAKEPRI (bitsOrWith fromFacility facs) (bitsOrWith fromPriority pris)
 
-foreign import ccall unsafe "syslog" _syslogSafe
+foreign import ccall unsafe "syslog" _syslogEscaped
   :: CInt -> CString -> CString -> IO ()
 
-syslogSafe :: CString -> [Facility] -> [Priority] -> ByteString -> IO ()
-syslogSafe esc facs pris msg =
-    useAsCString msg (_syslogSafe (makePri facs pris) esc)
+syslogEscaped :: CString -> [Facility] -> [Priority] -> ByteString -> IO ()
+syslogEscaped esc facs pris msg =
+    useAsCString msg (_syslogEscaped (makePri facs pris) esc)
 
 escape :: ByteString
 escape = "%s"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -14,7 +14,7 @@ instance Arbitrary Facility where
   arbitrary = arbitraryBoundedEnum
 
 instance Arbitrary ByteString where
-  arbitrary = pack <$> arbitrary
+  arbitrary = fmap pack arbitrary
 
 main :: IO ()
 main = do

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import Data.ByteString.Char8
+import System.Posix.Syslog
+import Test.QuickCheck
+import Test.QuickCheck.Property
+
+instance Arbitrary Priority where
+  arbitrary = arbitraryBoundedEnum
+
+instance Arbitrary Facility where
+  arbitrary = arbitraryBoundedEnum
+
+instance Arbitrary ByteString where
+  arbitrary = pack <$> arbitrary
+
+main :: IO ()
+main = do
+  dontExplodeTest
+  outputTest
+
+{--
+ This isn't a true test. Instead, we're passing the PERROR option (meaning
+ syslog will also send messages to STDERR), sending a message that should be
+ whitelisted by the priority mask, and sending a message that should be
+ blacklisted by the priority mask. If hsyslog is working correctly, then only
+ "hsyslog is working" should appear in your test log output.
+--}
+outputTest :: IO ()
+outputTest = withSyslog config $ \syslog -> do
+    syslog [Debug, Error] "%s%d hsyslog is working :)"
+    syslog [Error] "hsyslog is not working :("
+  where
+    config = defaultConfig
+        { options = [PERROR, NDELAY]
+        , priorityMask = Mask [Debug, Alert]
+        }
+
+dontExplodeTest :: IO ()
+dontExplodeTest = withSyslogTo defaultConfig $ \syslogTo -> do
+    let
+      prop_dontExplode :: [Facility] -> [Priority] -> ByteString -> Property
+      prop_dontExplode facs pris msg = ioProperty $ do
+          syslogTo facs pris msg
+          return succeeded
+    quickCheck prop_dontExplode


### PR DESCRIPTION
Hello! We're relying on hsyslog at Thoughtleadr, and took the time to implement the enhancements you listed (#6, #7, #8). I also wanted to harden the API, preventing users from accidentally sending calls to an unopened syslog socket— hence the modified `withSyslog`.

Would you like to pull these changes into upstream? If not, are there any edits you'd prefer to make it acceptable? Please let me know. And apologies for the large diff.

Thanks!