### PR TITLE
Bug fix resulting in API change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # ignore cabal build files
 
 /dist
+.cabal-sandbox
+cabal.sandbox.config

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hsyslog
 
 - Documentation can be found on [hackage][1].
-- Implementation is guided by the [GNU libc syslog documentation][2].
+- Implementation is guided by the [POSIX 1.2008 documentation][2].
 
-  [1]: http://hackage.haskell.org/package/hsyslog-2.0
-  [2]: http://www.gnu.org/software/libc/manual/html_node/Submitting-Syslog-Messages.html
+  [1]: http://hackage.haskell.org/package/hsyslog
+  [2]: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/syslog.h.html

--- a/hsyslog.cabal
+++ b/hsyslog.cabal
@@ -9,9 +9,8 @@ Homepage:               http://github.com/peti/hsyslog
 Bug-Reports:            http://github.com/peti/hsyslog/issues
 Category:               Foreign
 Synopsis:               FFI interface to syslog(3) from POSIX.1-2001
-Description:            This library provides FFI bindings to syslog(3) from POSIX.1-2001.
-                        See <http://www.opengroup.org/onlinepubs/009695399/basedefs/syslog.h.html> for
-                        further details.
+Description:            This library provides FFI bindings to syslog(3) from
+                        <http://www.opengroup.org/onlinepubs/009695399/basedefs/syslog.h.html POSIX.1-2001>.
 Cabal-Version:          >= 1.8
 Build-Type:             Simple
 Tested-With:            GHC > 7.6 && < 8.1

--- a/hsyslog.cabal
+++ b/hsyslog.cabal
@@ -10,7 +10,7 @@ Bug-Reports:            http://github.com/peti/hsyslog/issues
 Category:               Foreign
 Synopsis:               FFI interface to syslog(3) from POSIX.1-2001
 Description:            This library provides FFI bindings to syslog(3) from
-                        <http://www.opengroup.org/onlinepubs/009695399/basedefs/syslog.h.html POSIX.1-2001>.
+                        <http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/syslog.h.html POSIX.1-2008>.
 Cabal-Version:          >= 1.8
 Build-Type:             Simple
 Tested-With:            GHC > 7.6 && < 8.1

--- a/src/System/Posix/Syslog.hsc
+++ b/src/System/Posix/Syslog.hsc
@@ -15,7 +15,7 @@
    Portability :  Posix
 
    FFI bindings to syslog(3) from
-   <http://www.opengroup.org/onlinepubs/009695399/basedefs/syslog.h.html POSIX.1-2001>.
+   <http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/syslog.h.html POSIX.1-2008>.
 -}
 
 module System.Posix.Syslog
@@ -41,7 +41,7 @@ module System.Posix.Syslog
   , syslogUnsafe
     -- * Low-level C functions
     -- | See the
-    -- <http://www.gnu.org/software/libc/manual/html_node/Submitting-Syslog-Messages.html GNU libc documentation>.
+    -- <http://pubs.opengroup.org/onlinepubs/9699919799/functions/closelog.html POSIX.1-2008 documentation>.
   , _openlog
   , _closelog
   , _setlogmask

--- a/src/System/Posix/Syslog.hsc
+++ b/src/System/Posix/Syslog.hsc
@@ -35,26 +35,18 @@ module System.Posix.Syslog
   , SyslogConfig (..)
   , defaultConfig
     -- * The preferred Haskell API to syslog
-    -- | These are also the most performant calls to syslog, with the minimum
-    -- amount of 'CString' copying necessary.
   , withSyslog
   , SyslogFn
-  , withSyslogTo
-  , SyslogToFn
     -- * The unsafe Haskell API to syslog
-    -- | Using these functions provides no guarantee that a call to '_openlog'
-    -- has been made.
   , syslogUnsafe
-  , syslogToUnsafe
     -- * Low-level C functions
+    -- | See the
+    -- <http://www.gnu.org/software/libc/manual/html_node/Submitting-Syslog-Messages.html GNU libc documentation>.
   , _openlog
   , _closelog
   , _setlogmask
   , _syslog
     -- ** Low-level C macros
-    -- | See the
-    -- <http://www.gnu.org/software/libc/manual/html_node/Submitting-Syslog-Messages.html GNU libc documentation>
-    -- for their intended usage.
   , _LOG_MASK
   , _LOG_UPTO
   , _LOG_MAKEPRI
@@ -83,7 +75,7 @@ import GHC.Generics (Generic)
 #define LOG_PERROR 0
 #endif
 
--- |Log messages have a priority attached.
+-- | Log messages have a priority attached.
 
 data Priority
   = Emergency   -- ^ system is unusable
@@ -121,8 +113,8 @@ fromPriority Notice    = #{const LOG_NOTICE}
 fromPriority Info      = #{const LOG_INFO}
 fromPriority Debug     = #{const LOG_DEBUG}
 
--- |Syslog distinguishes various system facilities. Most
--- applications should log in 'USER'.
+-- | Syslog distinguishes various system facilities. Most applications should
+-- log in 'USER'.
 
 data Facility
   = KERN        -- ^ kernel messages
@@ -145,7 +137,11 @@ data Facility
   | LOCAL5      -- ^ reserved for local use
   | LOCAL6      -- ^ reserved for local use
   | LOCAL7      -- ^ reserved for local use
-  deriving (Bounded, Enum, Eq, Show, Read)
+  deriving ( Bounded, Enum, Eq, Show, Read
+#if __GLASGOW_HASKELL__ >= 706
+           , Generic
+#endif
+           )
 
 toFacility :: CInt -> Facility
 toFacility #{const LOG_KERN}      = KERN
@@ -192,7 +188,7 @@ fromFacility LOCAL5    = #{const LOG_LOCAL5}
 fromFacility LOCAL6    = #{const LOG_LOCAL6}
 fromFacility LOCAL7    = #{const LOG_LOCAL7}
 
--- |'withSyslog' options for the syslog service.
+-- | 'withSyslog' options for the syslog service.
 
 data Option
   = PID       -- ^ log the pid with each message
@@ -201,7 +197,11 @@ data Option
   | NDELAY    -- ^ don't delay open
   | NOWAIT    -- ^ don't wait for console forks: DEPRECATED
   | PERROR    -- ^ log to 'stderr' as well (might be a no-op on some systems)
-  deriving (Bounded, Enum, Eq, Show)
+  deriving ( Bounded, Enum, Eq, Show, Read
+#if __GLASGOW_HASKELL__ >= 706
+           , Generic
+#endif
+           )
 
 toOption :: CInt -> Option
 toOption #{const LOG_PID}     = PID
@@ -220,13 +220,17 @@ fromOption NDELAY  = #{const LOG_NDELAY}
 fromOption NOWAIT  = #{const LOG_NOWAIT}
 fromOption PERROR  = #{const LOG_PERROR}
 
--- |`withSyslog` options for the priority mask
+-- | 'withSyslog' options for the priority mask.
 
 data PriorityMask
   = NoMask          -- ^ allow all messages thru
   | Mask [Priority] -- ^ allow only messages with the priorities listed
   | UpTo Priority   -- ^ allow only messages down to and including the specified priority
-  deriving (Eq, Show)
+  deriving ( Eq, Show, Read
+#if __GLASGOW_HASKELL__ >= 706
+           , Generic
+#endif
+           )
 
 fromPriorityMask :: PriorityMask -> CInt
 fromPriorityMask (Mask pris) = bitsOrWith (_LOG_MASK . fromPriority) pris
@@ -241,16 +245,24 @@ data SyslogConfig = SyslogConfig
   }
   deriving (Eq, Show)
 
--- |A practical default syslog config. You'll at least want to change the
+-- | A practical default syslog config. You'll at least want to change the
 -- identifier.
 
 defaultConfig :: SyslogConfig
 defaultConfig = SyslogConfig "hsyslog" [ODELAY] [USER] NoMask
 
--- |Bracket an 'IO' computation between calls to '_openlog', '_setlogmask', and
--- '_closelog', and provide a logging function which can be used as follows:
+-- | Bracket an 'IO' computation between calls to '_openlog', '_setlogmask',
+-- and '_closelog', providing a logging function which can be used as follows:
 --
 -- > main = withSyslog defaultConfig $ \syslog -> do
+-- >          putStrLn "huhu"
+-- >          syslog [User] [Debug] "huhu"
+--
+-- Don't need per-message facilities? Passing an empty list logs to the default
+-- facilities in your `SyslogConfig`.
+--
+-- > main = withSyslog defaultConfig $ \syslogWithFacs -> do
+-- >          let syslog = syslogWithFacs []
 -- >          putStrLn "huhu"
 -- >          syslog [Debug] "huhu"
 --
@@ -259,100 +271,8 @@ defaultConfig = SyslogConfig "hsyslog" [ODELAY] [USER] NoMask
 
 withSyslog :: SyslogConfig -> (SyslogFn -> IO ()) -> IO ()
 withSyslog config f =
-    withinOpenCloseSyslog config $ do
-      useAsCString escape (f . flip syslogEscaped [])
-      return ()
-
--- |The type of logging function provided by 'withSyslog'.
-
-type SyslogFn
-  =  [Priority] -- ^ the priorities under which to log
-  -> ByteString -- ^ the message to log
-  -> IO ()
-
--- |Like 'withSyslog' but provides a function for logging to specific
--- facilities per message rather than the default facilities in your
--- 'SyslogConfig'.
-
-withSyslogTo :: SyslogConfig -> (SyslogToFn -> IO ()) -> IO ()
-withSyslogTo config f =
-    withinOpenCloseSyslog config $ do
-      useAsCString escape (f . syslogEscaped)
-      return ()
-
--- |The type of function provided by 'withSyslogTo'.
-
-type SyslogToFn
-  =  [Facility] -- ^ the facilities to log to
-  -> [Priority] -- ^ the priorities under which to log
-  -> ByteString -- ^ the message to log
-  -> IO ()
-
-syslogUnsafe :: SyslogFn
-syslogUnsafe = syslogToUnsafe []
-
-syslogToUnsafe :: SyslogToFn
-syslogToUnsafe facs pris msg = useAsCString msg (_syslog (makePri facs pris))
-
--- |Open a connection to the system logger for a program. The string
--- identifier passed as the first argument is prepended to every
--- message, and is typically set to the program name. The behavior is
--- unspecified by POSIX.1-2008 if that identifier is 'nullPtr'.
-
-foreign import ccall unsafe "openlog" _openlog :: CString -> CInt -> CInt -> IO ()
-
--- |Close the descriptor being used to write to the system logger.
-
-foreign import ccall unsafe "closelog" _closelog :: IO ()
-
--- |A process has a log priority mask that determines which calls to
--- syslog may be logged. All other calls will be ignored. Logging is
--- enabled for the priorities that have the corresponding bit set in
--- mask. The initial mask is such that logging is enabled for all
--- priorities. This function sets this logmask for the calling process,
--- and returns the previous mask. If the mask argument is 0, the current
--- logmask is not modified.
-
-foreign import ccall unsafe "setlogmask" _setlogmask :: CInt -> IO CInt
-
--- |Generate a log message, which will be distributed by @syslogd(8)@.
--- The priority argument is formed by ORing the facility and the level
--- values (explained below). The remaining arguments are a format, as in
--- printf(3) and any arguments required by the format, except that the
--- two character sequence %m will be replaced by the error message
--- string strerror(errno). A trailing newline may be added if needed.
-
-_syslog :: CInt -> CString -> IO ()
-_syslog int msg = useAsCString escape $ \e -> _syslogEscaped int e msg
-
-foreign import capi "syslog.h LOG_MASK" _LOG_MASK :: CInt -> CInt
-foreign import capi "syslog.h LOG_UPTO" _LOG_UPTO :: CInt -> CInt
-foreign import capi "syslog.h LOG_MAKEPRI" _LOG_MAKEPRI :: CInt -> CInt -> CInt
-
--- internal functions
-
-bitsOrWith :: (Bits b, Num b) => (a -> b) -> [a] -> b
-bitsOrWith f = foldl' (\bits x -> f x .|. bits) 0
-
-makePri :: [Facility] -> [Priority] -> CInt
-makePri facs pris =
-    _LOG_MAKEPRI (bitsOrWith fromFacility facs) (bitsOrWith fromPriority pris)
-
-foreign import ccall unsafe "syslog" _syslogEscaped
-  :: CInt -> CString -> CString -> IO ()
-
-syslogEscaped :: CString -> [Facility] -> [Priority] -> ByteString -> IO ()
-syslogEscaped esc facs pris msg =
-    useAsCString msg (_syslogEscaped (makePri facs pris) esc)
-
-escape :: ByteString
-escape = "%s"
-
-withinOpenCloseSyslog :: SyslogConfig -> IO () -> IO ()
-withinOpenCloseSyslog config run =
     useAsCString (identifier config) $ \cIdent ->
       let
-
         open :: IO ()
         open = do
             _openlog cIdent cOpts cFacs
@@ -366,4 +286,55 @@ withinOpenCloseSyslog config run =
         close :: IO ()
         close = _closelog
 
-      in bracket_ open close run
+        run :: IO ()
+        run = do
+            useAsCString escape (f . syslogEscaped)
+            return ()
+      in
+        bracket_ open close run
+
+-- | The type of function provided by 'withSyslog'.
+
+type SyslogFn
+  =  [Facility] -- ^ the facilities to log to
+  -> [Priority] -- ^ the priorities under which to log
+  -> ByteString -- ^ the message to log
+  -> IO ()
+
+-- | Provides no guarantee that a call to '_openlog' has been made, inviting
+-- unpredictable results.
+
+syslogUnsafe :: SyslogFn
+syslogUnsafe facs pris msg = useAsCString msg (_syslog (makePri facs pris))
+
+-- foreign imports
+
+foreign import ccall unsafe "openlog" _openlog :: CString -> CInt -> CInt -> IO ()
+foreign import ccall unsafe "closelog" _closelog :: IO ()
+foreign import ccall unsafe "setlogmask" _setlogmask :: CInt -> IO CInt
+
+foreign import ccall unsafe "syslog" _syslogEscaped
+  :: CInt -> CString -> CString -> IO ()
+
+_syslog :: CInt -> CString -> IO ()
+_syslog int msg = useAsCString escape $ \e -> _syslogEscaped int e msg
+
+foreign import capi "syslog.h LOG_MASK" _LOG_MASK :: CInt -> CInt
+foreign import capi "syslog.h LOG_UPTO" _LOG_UPTO :: CInt -> CInt
+foreign import capi "syslog.h LOG_MAKEPRI" _LOG_MAKEPRI :: CInt -> CInt -> CInt
+
+-- internal functions
+
+bitsOrWith :: (Bits b, Num b) => (a -> b) -> [a] -> b
+bitsOrWith f = foldl' (\bits x -> f x .|. bits) 0
+
+escape :: ByteString
+escape = "%s"
+
+makePri :: [Facility] -> [Priority] -> CInt
+makePri facs pris =
+    _LOG_MAKEPRI (bitsOrWith fromFacility facs) (bitsOrWith fromPriority pris)
+
+syslogEscaped :: CString -> [Facility] -> [Priority] -> ByteString -> IO ()
+syslogEscaped esc facs pris msg =
+    useAsCString msg (_syslogEscaped (makePri facs pris) esc)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -30,8 +30,8 @@ main = do
 --}
 outputTest :: IO ()
 outputTest = withSyslog config $ \syslog -> do
-    syslog [Debug, Error] "%s%d hsyslog is working :)"
-    syslog [Error] "hsyslog is not working :("
+    syslog [] [Debug, Error] "%s%d hsyslog is working :)"
+    syslog [] [Error] "hsyslog is not working :("
   where
     config = defaultConfig
         { options = [PERROR, NDELAY]
@@ -39,10 +39,9 @@ outputTest = withSyslog config $ \syslog -> do
         }
 
 dontExplodeTest :: IO ()
-dontExplodeTest = withSyslogTo defaultConfig $ \syslogTo -> do
+dontExplodeTest = withSyslog defaultConfig $ \syslog -> do
     let
       prop_dontExplode :: [Facility] -> [Priority] -> ByteString -> Property
       prop_dontExplode facs pris msg = ioProperty $ do
-          syslogTo facs pris msg
+          syslog facs pris msg
           return succeeded
-    quickCheck prop_dontExplode

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -18,8 +18,8 @@ instance Arbitrary ByteString where
 
 main :: IO ()
 main = do
-  dontExplodeTest
   outputTest
+  dontExplodeTest
 
 {--
  This isn't a true test. Instead, we're passing the PERROR option (meaning
@@ -30,8 +30,8 @@ main = do
 --}
 outputTest :: IO ()
 outputTest = withSyslog config $ \syslog -> do
-    syslog [] [Debug, Error] "%s%d hsyslog is working :)"
-    syslog [] [Error] "hsyslog is not working :("
+    syslog USER Debug "%s%d hsyslog is working :)"
+    syslog USER Error "hsyslog is not working :("
   where
     config = defaultConfig
         { options = [PERROR, NDELAY]
@@ -41,7 +41,8 @@ outputTest = withSyslog config $ \syslog -> do
 dontExplodeTest :: IO ()
 dontExplodeTest = withSyslog defaultConfig $ \syslog -> do
     let
-      prop_dontExplode :: [Facility] -> [Priority] -> ByteString -> Property
-      prop_dontExplode facs pris msg = ioProperty $ do
-          syslog facs pris msg
+      prop_dontExplode :: Facility -> Priority -> ByteString -> Property
+      prop_dontExplode fac pri msg = ioProperty $ do
+          syslog fac pri msg
           return succeeded
+    quickCheck prop_dontExplode


### PR DESCRIPTION
When studying the `syslog.h` documentation, I mistakenly believed `Priority` and `Facility` to be bit-masks the same way `Option` and `PriorityMask` constants are. Turns out that's not the case. I missed this in testing, because the bitwise-OR'ed values result in the same or higher values, which is thankfully harmless for priorities. It _is_ harmful for facilities, though.

Worse, fixing this bug results in an interface change, as `[Facility]` and `[Priority]` are no longer valid arguments (since they can't be OR'ed). I can't believe I caught this immediately after release, and not before.

I sincerely apologize for springing this on you. I know Hackage makes it hell to fix or deprecate releases, but 3.0 shouldn't be used.

While I was in there, I removed `withSyslogTo`, since it supplies almost no value post-changes, and anybody wanting a syslog function sans facility can simply curry the first argument.

Again, sincere apologies. 🙏  🙏  🙏 